### PR TITLE
Use stop instead of kill

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 dcorefresh lets you update one or more docker-compose services through a simple CLI interface, so that you no longer will have to type a bunch of long service names.
 
-***Refresh***: *The act of running kill, build and up on a docker-compose service. Yes, i made it up.*
+***Refresh***: *The act of running stop, build and up on a docker-compose service. Yes, i made it up.*
 
 ## Installation and usage
 In order to use dcorefresh, you will need to have docker-compose installed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dcorefresh",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcorefresh",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Node based CLI tool for refreshing docker-compose services",
   "main": "index.js",
   "engines": {

--- a/util.js
+++ b/util.js
@@ -5,7 +5,7 @@ const exec = promisify(require('child_process').exec, { multiArgs: true })
 // Kills, rebuilds and restarts service
 exports.refresh = async function(service) {
 	const { err, stdout, stderr } = await exec(`
-		docker-compose kill ${service} &&
+		docker-compose stop ${service} &&
 		docker-compose build ${service} &&
 		docker-compose up -d ${service}`
 	);


### PR DESCRIPTION
Use `docker-compose stop` instead of `docker-compose kill` to allow services to shutdown gracefully.